### PR TITLE
Fix compilation issues and fix config.ini

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -33,7 +33,7 @@ baudrate:6
 # Options: [ENGLISH: 0,  CHINESE: 1,  RUSSIAN: 2,  JAPANESE: 3,    ARMENIAN: 4,
 #            GERMAN: 5,    CZECH: 6,    SPAIN: 7,    FRENCH: 8,  PORTUGUESE: 9,
 #           ITALIAN: 10,  POLISH: 11,  SLOVAK: 12,    DUTCH: 13,  HUNGARIAN: 14,
-#           TURKISH: 15,   GREEK: 16]
+#           TURKISH: 15,   GREEK: 16,   SLOVENIAN: 17]
 language:0
 
 #### Default Touch Mode Color Options
@@ -88,7 +88,6 @@ persistent_info:0
 # Options: [enable: 1, disable: 0]
 files_list_mode:1
 
-
 #--------------------------------------------------------------------
 # Marlin Mode Settings (Only for TFT35_V3.0/ TFT24_V1.1/ TFT28V3.0)
 #--------------------------------------------------------------------
@@ -138,6 +137,16 @@ ext_count:1
 #### Fan Count
 # Options: [1 to 6]
 fan_count:1
+
+#### CNC Mode
+# Select to change the mode to be mostly CNC related.
+# Options: [CNC Mode: 1, Printer Mode: 0]
+cnc_mode:1
+
+#### Laser Mode
+# Select to change the fan settings to a laser.
+# Options: [Laser mode: 1, Fan mode: 0]
+laser_mode:1
 
 #### Bed / Extruder Maximum Temperatures
 # format [max_temp: BED:<max temp> T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp>]
@@ -237,6 +246,18 @@ preheat_name4:TPU
 preheat_temp4:T220 B50
 
 #--------------------------------------------------------------------
+# Z min Touch Plate
+#--------------------------------------------------------------------
+
+#### Default Touch Plate Mode
+# Options: [OFF: 0, ON: 1:]
+touchplate_on:1
+
+#### Z Offset for touch plate height
+# Plate thickness in mm (G92 Zx.xx)
+touchplate_height:0.5
+
+#--------------------------------------------------------------------
 # Power Supply Settings (if connected to TFT Controller)
 #--------------------------------------------------------------------
 
@@ -330,7 +351,7 @@ custom_label_2:Init sd card
 custom_gcode_2:M21\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
-custom_label_4:restore leveling
+custom_label_4:Restore leveling
 custom_gcode_4:M420 S1\n
 custom_label_5:Save to EEPROM
 custom_gcode_5:M500\n
@@ -381,4 +402,4 @@ cancel_gcode_enabled:0
 
 #### Cancel G-code - run this G-code after canceling print
 # maximum length 50 characters
-#cancel_gcode:G28 XY R10\n
+cancel_gcode:G28 XY R10\n

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -22,18 +22,18 @@
 #### UNIFIED MENU / CLASSIC MENU
 # Select a UI Menu flavour
 # Options: [Unified Menu: 1, Classic Menu: 0]
-unified_menu:0
+unified_menu:1
 
 #### Baudrate
 # Options: [2400: 0, 9600: 1, 19200: 2, 38400: 3, 57600: 4, 115200: 5, 250000: 6, 500000: 7, 1000000: 8]
-baudrate:5
+baudrate:6
 
 #### Default Touch Mode Language
 # Select the language to display on the LCD while in Touch Mode.
 # Options: [ENGLISH: 0,  CHINESE: 1,  RUSSIAN: 2,  JAPANESE: 3,    ARMENIAN: 4,
 #            GERMAN: 5,    CZECH: 6,    SPAIN: 7,    FRENCH: 8,  PORTUGUESE: 9,
 #           ITALIAN: 10,  POLISH: 11,  SLOVAK: 12,    DUTCH: 13,  HUNGARIAN: 14,
-#           TURKISH: 15,   GREEK: 16]
+#           TURKISH: 15,   GREEK: 16,   SLOVENIAN: 17]
 language:0
 
 #### Default Touch Mode Color Options
@@ -88,7 +88,6 @@ persistent_info:0
 # Options: [enable: 1, disable: 0]
 files_list_mode:1
 
-
 #--------------------------------------------------------------------
 # Marlin Mode Settings (Only for TFT35_V3.0/ TFT24_V1.1/ TFT28V3.0)
 #--------------------------------------------------------------------
@@ -109,7 +108,7 @@ serial_always_on:0
 # Or set the color(RGB888 format) hex value directly(start with “0x”).
 # Such as: 0xFF0000 : Red, 0x00FF00 : Green, 0x0000FF : Blue
 marlin_bg_color:1
-marlin_fn_color:8
+marlin_fn_color:2
 
 #### Marlin Mode show title
 # Options: [enable: 1, disable: 0]
@@ -139,12 +138,22 @@ ext_count:1
 # Options: [1 to 6]
 fan_count:1
 
+#### CNC Mode
+# Select to change the mode to be mostly CNC related.
+# Options: [CNC Mode: 1, Printer Mode: 0]
+cnc_mode:1
+
+#### Laser Mode
+# Select to change the fan settings to a laser.
+# Options: [Laser mode: 1, Fan mode: 0]
+laser_mode:1
+
 #### Bed / Extruder Maximum Temperatures
 # format [max_temp: BED:<max temp> T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp>]
 max_temp:BED:150 T0:275 T1:275 T2:275 T3:275 T4:275 T5:275
 
 #### Cold Extrusion Minimum Temperature
-min_temp:180
+min_temp:170
 
 #### Fan Maximum PWM speed (0 to 255)
 # format [fan_max: F0:<max temp> F1:<max temp> F2:<max temp> F3:<max temp> F4:<max temp> F5:<max temp>]
@@ -156,12 +165,12 @@ fan_max:F0:255 F1:255 F2:255 F3:255 F4:255 F5:255
 # minimum size limit format [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
 # maximum size limit format [size_max: X<maximum distance> Y<maximum distance> Z<maximum distance>]
 size_min:X0 Y0 Z0
-size_max:X235 Y235 Z250
+size_max:X300 Y300 Z250
 
 #### default Move Speeds (mm/min)
 # Options: [Slow: S, Normal: N, Fast: F]
 # format   [move_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
-move_speed:S1000 N3000 F5000
+move_speed:S1000 N2100 F3000
 
 #### default Extruder Speeds (mm/min)
 # Options: [Slow: S, Normal: N, Fast: F]
@@ -205,10 +214,10 @@ fan_speed_percent:1
 # Pause XY position format      [pause_pos: X<position in mm> Y<position in mm>]
 # Pause Z raise format          [pause_z_raise: Z<distance in mm>]
 # Pause feed Rate # format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min> E<feedrate mm/min>]
-pause_retract:R15 P16
-pause_pos:X10 Y10
-pause_z_raise:20
-pause_feedrate:X6000 Y6000 Z6000 E600
+#pause_retract:R15 P16
+#pause_pos:X10 Y10
+#pause_z_raise:20
+#pause_feedrate:X6000 Y6000 Z6000 E600
 
 ### Manual Level Points Edge distance (mm)
 # distance in mm, Feedrates in mm/min
@@ -235,6 +244,18 @@ preheat_temp3:T230 B90
 
 preheat_name4:TPU
 preheat_temp4:T220 B50
+
+#--------------------------------------------------------------------
+# Z min Touch Plate
+#--------------------------------------------------------------------
+
+#### Default Touch Plate Mode
+# Options: [OFF: 0, ON: 1:]
+touchplate_on:1
+
+#### Z Offset for touch plate height
+# Plate thickness in mm (G92 Zx.xx)
+touchplate_height:0.5
 
 #--------------------------------------------------------------------
 # Power Supply Settings (if connected to TFT Controller)
@@ -298,7 +319,7 @@ buzzer:1
 
 #### Knob Led Color (only for TFT35 E3.0)
 #Options: [LED_OFF: 0, LED_WHITE: 1, LED_RED: 2, LED_ORANGE: 3, LED_YELLOW: 4, LED_GREEN: 5, LED_BLUE: 6, LED_INDIGO: 7, LED_VIOLET: 8]
-knob_led_color:0
+knob_led_color:2
 
 #### Default LCD Brightness levels (only for TFT35v3.0 & TFT28v3.0)
 # Options: [(low) 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 (full)]
@@ -330,11 +351,11 @@ custom_label_2:Init sd card
 custom_gcode_2:M21\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
-custom_label_4:restore leveling
+custom_label_4:Restore leveling
 custom_gcode_4:M420 S1\n
 custom_label_5:Save to EEPROM
 custom_gcode_5:M500\n
-custom_label_6:restore from EEPROM
+custom_label_6:Restore from EEPROM
 custom_gcode_6:M501\n
 custom_label_7:EEPROM defaults
 custom_gcode_7:M502\n
@@ -373,11 +394,11 @@ cancel_gcode_enabled:0
 
 #### Start G-code - run this G-code before starting print
 # maximum length 50 characters
-start_gcode:G28 XY R20\n
+#start_gcode:G28 XY R20\n
 
 #### End G-code - run this G-code after finishing print
 # maximum length 50 characters
-end_gcode:G90\nG1 E-4\nG92 E0\nM18\n
+#end_gcode:G90\nG1 E-4\nG92 E0\nM18\n
 
 #### Cancel G-code - run this G-code after canceling print
 # maximum length 50 characters

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,7 +82,7 @@ build_flags = ${common.build_flags}
 # BIGTREE TFT35 V1.0
 #
 [env:BIGTREE_TFT35_V1_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -100,7 +100,7 @@ build_flags   = ${stm32f10x.build_flags}
 # BIGTREE TFT35 V1.1
 #
 [env:BIGTREE_TFT35_V1_1]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -118,7 +118,7 @@ build_flags   = ${stm32f10x.build_flags}
 # BIGTREE TFT35 V1.2
 #
 [env:BIGTREE_TFT35_V1_2]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -136,7 +136,7 @@ build_flags   = ${stm32f10x.build_flags}
 # BIGTREE TFT35 V2.0
 #
 [env:BIGTREE_TFT35_V2_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -155,7 +155,7 @@ monitor_speed = 250000
 # BIGTREE TFT35 V3.0
 #
 [env:BIGTREE_TFT35_V3_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -173,7 +173,7 @@ build_flags   = ${stm32f2xx.build_flags}
 # BIGTREE TFT35 E3 V3.0
 #
 [env:BIGTREE_TFT35_E3_V3_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -191,7 +191,7 @@ build_flags   = ${stm32f2xx.build_flags}
 # BIGTREE TFT43 V3.0
 #
 [env:BIGTREE_TFT43_V3_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -209,7 +209,7 @@ build_flags   = ${stm32f2xx.build_flags}
 # BIGTREE TFT50 V3.0
 #
 [env:BIGTREE_TFT50_V3_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -227,7 +227,7 @@ build_flags   = ${stm32f2xx.build_flags}
 # BIGTREE TFT70 V3.0
 #
 [env:BIGTREE_TFT70_V3_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -245,7 +245,7 @@ build_flags   = ${stm32f4xx.build_flags}
 # BIGTREE TFT28 V1.0
 #
 [env:BIGTREE_TFT28_V1_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -263,7 +263,7 @@ build_flags   = ${stm32f10x.build_flags}
 # BIGTREE TFT28 V3.0
 #
 [env:BIGTREE_TFT28_V3_0]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F103VC
 upload_protocol = cmsis-dap
@@ -281,7 +281,7 @@ build_flags   = ${stm32f2xx.build_flags}
 # BIGTREE TFT24 V1.1
 #
 [env:BIGTREE_TFT24_V1_1]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F105RC
 upload_protocol = cmsis-dap
@@ -299,7 +299,7 @@ build_flags   = ${stm32f10x.build_flags}
 # MKS TFT32 V1.4
 #
 [env:MKS_32_V1_4]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F107VC
 upload_protocol = stlink
@@ -318,7 +318,7 @@ build_flags   = ${stm32f10x.build_flags}
 # MKS TFT32 V1.4 No Bootloader
 #
 [env:MKS_32_V1_4_NOBL]
-platform      = ststm32
+platform      = ststm32@9.0.0
 framework     = stm32cube
 board         = STM32F107VC
 upload_protocol = stlink


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The config.ini file is not complete. It's missing the `cnc_menu` options among other things, so when the TFT screen is flashed it doesn't show the CNC specific interface.

It also sets the platform to `ststm32@9.0.0` to fix compilation issues.

### Benefits

It updates the config.ini file so it works and makes it possible to compile the project :)

### Related Issues

-